### PR TITLE
add template for team roster 

### DIFF
--- a/admin/team.md
+++ b/admin/team.md
@@ -6,3 +6,27 @@ In a previous lab exercise you made individual developer pages; now it is time t
 Your team page should have the team name, brand, any values you think are important, and a roster of all the team members.  The roster should provide a brief overview of each member with a link to their personal Github page.  The team page can include humor or whatever culture makes sense to your team, but keep it reasonable as it may be shown to others. 
 
 You will have to consult heavily with the "Team Brand" team. Have fun!
+
+## **Team Roster:**
+
+### *[Tucker Frandsen](https://tuckerfrandsen.github.io/CSE110-Lab1/)*
+
+### *[Delia McGrath](https://dmcgrath19.github.io/CSE110_Lab1/)*:
+- Computer science student from Trinity College Dublin, bringing the luck of the Irish to team 27
+- Enjoys leading the team with Tucker
+
+### *[Arturo Amaya](https://arturoamaya.github.io/CSE110Lab1/)*
+
+### *Tiffany Chang*
+
+### *Steven Christensen*
+
+### *[Dilara Marasli](https://dmarasli.github.io/CSE110-GitHubPages/#interests)*
+
+### *Aryan Malik*
+
+### *Miguel Christian Sanchez*
+
+### *Steven Schaeffer*
+
+### *Kevin Yu*


### PR DESCRIPTION
This will then allow each person to add their personal site(if not currently included) as well as add their about section.

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>