### PR TITLE
Update and rename node.js.yml to NodeTesting.yml

### DIFF
--- a/.github/workflows/NodeTesting.yml
+++ b/.github/workflows/NodeTesting.yml
@@ -1,7 +1,7 @@
 # This workflow will do a clean install of node dependencies, cache/restore them, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Node.js CI
+name: Node Testing
 
 on:
   push:
@@ -28,5 +28,3 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    - run: npm install --save-dev jest babel-jest @babel/core @babel/preset-env puppeteer jest-puppeteer
-    - run: npm run build --if-present


### PR DESCRIPTION
Updating the node test framework to not checkout a version of node that already has npm installed and then reinstall npm. It should now run multitudes faster. Also updated the name to be more reflective of the eventual functionality.